### PR TITLE
Add web dashboard for reconciliation runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A demonstration and testing platform that simulates multi-system key reconciliat
 - **Discrepancy Detection**: Identify out-of-authority keys, propagation gaps, and duplicates
 - **Master Key Provisioning**: Propose and manage master keys for unrecognized entries
 - **Comprehensive Reporting**: Generate 5+ CSV reports with detailed reconciliation results
+- **Interactive Dashboard**: Launch a lightweight web UI to trigger runs and explore outputs
 - **Multiple Execution Modes**: Normal, dry-run, and auto-approve modes
 - **Error Resilience**: Handle missing files, corrupted data, and partial system availability
 - **Performance Optimized**: Process 5,000+ keys per system in under 10 seconds
@@ -49,6 +50,21 @@ python src/keysync.py --dry-run
 # Auto-approve mode (activate master keys automatically)
 python src/keysync.py --auto-approve
 ```
+
+### Launch the Web Dashboard
+
+```bash
+# Install dependencies first (see Installation section)
+
+# Start the dashboard (default http://127.0.0.1:5000)
+python -m webapp.app
+
+# Alternatively, with Flask's CLI
+FLASK_APP=webapp.app flask run --host=0.0.0.0 --port=5000
+```
+
+The dashboard lets you configure a run, trigger reconciliation, and review key statistics,
+discrepancies, generated reports, and captured logs directly in the browser.
 
 ### Using the Convenience Script
 
@@ -148,6 +164,7 @@ keysync-mini/
 ├── logs/               # Application logs
 ├── keysync-config.yaml # Configuration file
 ├── requirements.txt    # Python dependencies
+├── webapp/             # Flask dashboard for running and reviewing simulations
 └── run.sh             # Convenience script
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 PyYAML>=6.0.1
 pandas>=2.0.0
 click>=8.1.0
+Flask>=3.0.0
 
 # Testing
 pytest>=7.4.0

--- a/tests/test_keysync_frontend.py
+++ b/tests/test_keysync_frontend.py
@@ -1,0 +1,83 @@
+"""Tests for the shared reconciliation runner and dashboard utilities."""
+
+from pathlib import Path
+
+from src.keysync import run_reconciliation
+from webapp.app import build_view_model
+
+
+def test_run_reconciliation_dry_run(tmp_path: Path):
+    """run_reconciliation should return structured results for consumers."""
+    output_dir = tmp_path / 'reports'
+
+    result = run_reconciliation(
+        config='keysync-config.yaml',
+        mode='full',
+        dry_run=True,
+        auto_approve=False,
+        generate_data=False,
+        scenario='normal',
+        keys=100,
+        seed=42,
+        output_dir=str(output_dir),
+    )
+
+    assert result['status'] == 'success'
+    assert result['results']
+    assert 'statistics' in result['results']['comparison']
+    assert result['reports'] == []  # dry-run skips report generation
+    assert result['generated_data'] is None
+    assert result['output_dir'] == str(output_dir)
+
+
+def test_build_view_model_handles_reconciliation_payload():
+    """build_view_model should normalize reconciliation payload structures."""
+    mock_results = {
+        'results': {
+            'timestamp': '2025-01-01T00:00:00',
+            'comparison': {
+                'statistics': {
+                    'total_unique_keys': 10,
+                    'keys_in_a': 8,
+                    'keys_in_all_systems': 6,
+                    'keys_only_in_a': 2,
+                    'keys_missing_in_a': 1,
+                    'match_percentage': 60.0,
+                    'system_counts': {'A': 8, 'B': 7},
+                    'duplicates': {'B': [['dup']]}},
+                'comparison': {
+                    'keys_only_in_a': {'A1'},
+                    'keys_missing_in_a': {'B1'}
+                },
+                'system_specific_gaps': {'B': {'A1', 'A2'}},
+            },
+            'discrepancies': {
+                'summary': {
+                    'total_out_of_authority': 1,
+                    'total_propagation_gaps': 2,
+                    'total_duplicate_groups': 1,
+                },
+                'propagation_gaps': {'B': ['A1']},
+                'out_of_authority_keys': {'B1': [('B', 'b1')]},
+                'duplicate_keys': {'B': [['dup']]},
+            },
+            'provisioning': [
+                {
+                    'master_key': 'B1',
+                    'source_system': 'B',
+                    'source_key': 'b1',
+                    'affected_systems': ['C'],
+                    'status': 'proposed',
+                }
+            ],
+        }
+    }
+
+    view = build_view_model(mock_results)
+
+    assert view['stats_items'][0][0] == 'Total Unique Keys'
+    assert view['propagation_gaps']['B'] == ['A1']
+    assert view['out_of_authority'][0]['normalized_key'] == 'B1'
+    assert view['provisioning'][0]['master_key'] == 'B1'
+    assert view['keys_only_in_a'] == ['A1']
+    assert view['keys_missing_in_a'] == ['B1']

--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -1,0 +1,5 @@
+"""Web application package for KeySync Mini."""
+
+from .app import create_app, app  # noqa: F401
+
+__all__ = ["create_app", "app"]

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,0 +1,246 @@
+"""Flask web application for interacting with KeySync Mini."""
+
+from __future__ import annotations
+
+import io
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+from flask import (
+    Flask,
+    abort,
+    flash,
+    redirect,
+    render_template,
+    request,
+    send_from_directory,
+    url_for,
+)
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+SRC_DIR = BASE_DIR / 'src'
+if str(SRC_DIR) not in sys.path:
+    sys.path.append(str(SRC_DIR))
+
+from src.logger import setup_logging
+from src.keysync import run_reconciliation
+
+SCENARIOS = ['normal', 'drift', 'failure', 'recovery']
+MODES = ['full', 'incremental']
+
+
+def create_app() -> Flask:
+    """Create and configure the Flask application."""
+    app = Flask(__name__)
+
+    secret_key = os.environ.get('KEYSYNC_SECRET_KEY', 'keysync-mini-demo')
+    app.config['SECRET_KEY'] = secret_key
+
+    output_dir = Path(os.environ.get('KEYSYNC_OUTPUT_DIR', 'output')).resolve()
+    app.config['OUTPUT_DIR'] = output_dir
+    app.config['LAST_RUN'] = None
+
+    log_level = os.environ.get('KEYSYNC_LOG_LEVEL', 'INFO')
+    log_file = os.environ.get('KEYSYNC_WEB_LOG', 'logs/keysync_web.log')
+    setup_logging(log_level=log_level, log_file=log_file)
+
+    @app.route('/', methods=['GET', 'POST'])
+    def index():
+        """Render the dashboard and handle reconciliation requests."""
+        default_config = os.environ.get('KEYSYNC_CONFIG_PATH', 'keysync-config.yaml')
+        default_output = app.config['OUTPUT_DIR']
+
+        if request.method == 'POST':
+            form = request.form
+            config_path = (form.get('config_path') or default_config).strip() or default_config
+            mode = form.get('mode', 'full')
+            scenario = form.get('scenario', 'normal')
+            generate_data = form.get('generate_data') == 'on'
+            dry_run = form.get('dry_run') == 'on'
+            auto_approve = form.get('auto_approve') == 'on'
+            verbose = form.get('verbose') == 'on'
+            output_directory_raw = (form.get('output_dir') or str(default_output)).strip()
+            output_directory = output_directory_raw or str(default_output)
+
+            try:
+                keys = int(form.get('keys') or 1000)
+            except ValueError:
+                flash('Keys per system must be an integer.', 'error')
+                return redirect(url_for('index'))
+
+            seed_raw = form.get('seed')
+            try:
+                seed = int(seed_raw) if seed_raw else None
+            except ValueError:
+                flash('Seed must be an integer.', 'error')
+                return redirect(url_for('index'))
+
+            if mode not in MODES:
+                flash('Invalid reconciliation mode selected.', 'error')
+                return redirect(url_for('index'))
+
+            if scenario not in SCENARIOS:
+                flash('Invalid scenario selected.', 'error')
+                return redirect(url_for('index'))
+
+            log_buffer = io.StringIO()
+            handler = logging.StreamHandler(log_buffer)
+            handler.setLevel(logging.DEBUG if verbose else logging.INFO)
+            handler.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(message)s'))
+
+            root_logger = logging.getLogger()
+            original_level = root_logger.level
+            if verbose and original_level > logging.DEBUG:
+                root_logger.setLevel(logging.DEBUG)
+
+            root_logger.addHandler(handler)
+
+            try:
+                run_details = run_reconciliation(
+                    config=config_path,
+                    mode=mode,
+                    dry_run=dry_run,
+                    auto_approve=auto_approve,
+                    generate_data=generate_data,
+                    scenario=scenario,
+                    keys=keys,
+                    seed=seed,
+                    output_dir=output_directory,
+                )
+                status = 'success'
+                flash(f"Reconciliation run {run_details['run_id']} completed successfully.", 'success')
+            except Exception as exc:  # pylint: disable=broad-except
+                run_details = {
+                    'status': 'error',
+                    'error': str(exc),
+                }
+                status = 'error'
+                flash(f'Reconciliation failed: {exc}', 'error')
+            finally:
+                root_logger.removeHandler(handler)
+                root_logger.setLevel(original_level)
+
+            run_details['mode'] = run_details.get('mode', mode)
+            run_details['scenario'] = scenario
+            run_details['dry_run'] = dry_run
+            run_details['auto_approve'] = auto_approve
+            run_details['generate_data'] = generate_data
+            run_details['keys'] = keys
+            run_details['seed'] = seed
+            run_details['logs'] = log_buffer.getvalue()
+            run_details['verbose'] = verbose
+            run_details['output_dir'] = output_directory
+            run_details['config_path'] = config_path
+            run_details['report_files'] = [
+                Path(path).name for path in run_details.get('reports', []) if path
+            ]
+            if run_details.get('json_report'):
+                run_details['json_report_name'] = Path(run_details['json_report']).name
+            else:
+                run_details['json_report_name'] = None
+            run_details['view'] = build_view_model(run_details)
+            run_details['status'] = status
+
+            app.config['LAST_RUN'] = run_details
+            app.config['OUTPUT_DIR'] = Path(output_directory).resolve()
+
+            return redirect(url_for('index'))
+
+        last_run = app.config.get('LAST_RUN')
+
+        return render_template(
+            'index.html',
+            scenarios=SCENARIOS,
+            modes=MODES,
+            default_config=default_config,
+            default_output=str(default_output),
+            last_run=last_run,
+        )
+
+    @app.route('/reports/<path:filename>')
+    def download_report(filename: str):
+        """Serve generated report files from the output directory."""
+        output_path = app.config.get('OUTPUT_DIR', Path('output')).resolve()
+        target = output_path / filename
+        if not target.exists() or not target.is_file():
+            abort(404)
+        return send_from_directory(output_path, filename, as_attachment=True)
+
+    return app
+
+
+def build_view_model(run_details: Dict[str, Any]) -> Dict[str, Any]:
+    """Prepare reconciliation results for display in templates."""
+    results = run_details.get('results') or {}
+    comparison = results.get('comparison') or {}
+    stats = comparison.get('statistics') or {}
+    discrepancies = results.get('discrepancies') or {}
+    provisioning = results.get('provisioning') or []
+
+    system_counts = stats.get('system_counts') or {}
+    discrepancy_summary = discrepancies.get('summary') or {}
+    propagation_gaps = discrepancies.get('propagation_gaps') or {}
+    out_of_authority = discrepancies.get('out_of_authority_keys') or {}
+    duplicate_keys = discrepancies.get('duplicate_keys') or {}
+
+    keys_only_in_a = comparison.get('comparison', {}).get('keys_only_in_a') if isinstance(comparison.get('comparison'), dict) else comparison.get('keys_only_in_a')
+    keys_missing_in_a = comparison.get('comparison', {}).get('keys_missing_in_a') if isinstance(comparison.get('comparison'), dict) else comparison.get('keys_missing_in_a')
+
+    def sorted_list(values: Any) -> list[Any]:
+        if values is None:
+            return []
+        if isinstance(values, set):
+            return sorted(values)
+        if isinstance(values, list):
+            return sorted(values)
+        return list(values)
+
+    view = {
+        'stats_items': [
+            ('Total Unique Keys', stats.get('total_unique_keys', 0)),
+            ('Keys in System A', stats.get('keys_in_a', 0)),
+            ('Keys in All Systems', stats.get('keys_in_all_systems', 0)),
+            ('Keys Only in A (Propagation Gaps)', stats.get('keys_only_in_a', 0)),
+            ('Keys Missing in A (Out of Authority)', stats.get('keys_missing_in_a', 0)),
+            ('Overall Match Rate', f"{stats.get('match_percentage', 0):.1f}%"),
+        ],
+        'system_counts': sorted(system_counts.items()),
+        'discrepancy_summary': [
+            ('Out-of-Authority Keys', discrepancy_summary.get('total_out_of_authority', 0)),
+            ('Propagation Gaps', discrepancy_summary.get('total_propagation_gaps', 0)),
+            ('Duplicate Key Groups', discrepancy_summary.get('total_duplicate_groups', 0)),
+        ],
+        'propagation_gaps': {system: sorted_list(keys) for system, keys in propagation_gaps.items()},
+        'out_of_authority': [
+            {
+                'normalized_key': key,
+                'sources': sources,
+            }
+            for key, sources in out_of_authority.items()
+        ],
+        'duplicate_counts': {
+            system: len(groups)
+            for system, groups in duplicate_keys.items()
+        },
+        'provisioning': provisioning,
+        'keys_only_in_a': sorted_list(keys_only_in_a or []),
+        'keys_missing_in_a': sorted_list(keys_missing_in_a or []),
+        'system_specific_gaps': {
+            system: sorted_list(keys)
+            for system, keys in (comparison.get('system_specific_gaps') or {}).items()
+        },
+        'timestamp': results.get('timestamp'),
+    }
+
+    return view
+
+
+app = create_app()
+
+
+if __name__ == '__main__':
+    port = int(os.environ.get('PORT', 5000))
+    app.run(host='0.0.0.0', port=port, debug=False)

--- a/webapp/static/styles.css
+++ b/webapp/static/styles.css
@@ -1,0 +1,26 @@
+body {
+  background-color: #f7f9fc;
+}
+
+.card + .card {
+  margin-top: 1.5rem;
+}
+
+pre.logs {
+  background-color: #111827;
+  color: #f9fafb;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  max-height: 320px;
+  overflow-y: auto;
+  font-size: 0.85rem;
+}
+
+details summary {
+  cursor: pointer;
+  font-weight: 600;
+}
+
+table tr td:first-child {
+  width: 60%;
+}

--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>KeySync Mini Dashboard</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+  </head>
+  <body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-4">
+      <div class="container-fluid">
+        <span class="navbar-brand">KeySync Mini Dashboard</span>
+      </div>
+    </nav>
+    <main class="container mb-5">
+      {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+          {% for category, message in messages %}
+            <div class="alert alert-{{ 'danger' if category == 'error' else category }}" role="alert">
+              {{ message }}
+            </div>
+          {% endfor %}
+        {% endif %}
+      {% endwith %}
+      {% block content %}{% endblock %}
+    </main>
+    <footer class="footer text-center py-4">
+      <div class="container">
+        <span class="text-muted">KeySync Mini &mdash; Mock reconciliation platform</span>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -1,0 +1,345 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="row g-4">
+  <div class="col-lg-4">
+    <div class="card shadow-sm">
+      <div class="card-header">Start a reconciliation run</div>
+      <div class="card-body">
+        <form method="post">
+          <div class="mb-3">
+            <label class="form-label" for="config_path">Configuration file</label>
+            <input class="form-control" id="config_path" name="config_path" type="text" value="{{ (last_run.config_path if last_run else default_config) | e }}" required>
+            <div class="form-text">Path to the YAML configuration file.</div>
+          </div>
+          <div class="mb-3">
+            <label class="form-label" for="output_dir">Output directory</label>
+            <input class="form-control" id="output_dir" name="output_dir" type="text" value="{{ (last_run.output_dir if last_run else default_output) | e }}">
+          </div>
+          <div class="mb-3">
+            <label class="form-label" for="mode">Reconciliation mode</label>
+            <select class="form-select" id="mode" name="mode">
+              {% for option in modes %}
+                {% set selected = (last_run.mode == option) if last_run else (option == 'full') %}
+                <option value="{{ option }}" {% if selected %}selected{% endif %}>{{ option|capitalize }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="mb-3">
+            <label class="form-label" for="scenario">Simulation scenario</label>
+            <select class="form-select" id="scenario" name="scenario">
+              {% for option in scenarios %}
+                {% set selected = (last_run.scenario == option) if last_run else (option == 'normal') %}
+                <option value="{{ option }}" {% if selected %}selected{% endif %}>{{ option|capitalize }}</option>
+              {% endfor %}
+            </select>
+            <div class="form-text">Only used when mock data generation is enabled.</div>
+          </div>
+          <div class="mb-3">
+            <label class="form-label" for="keys">Keys per system</label>
+            <input class="form-control" id="keys" name="keys" type="number" min="1" value="{{ last_run.keys if last_run else 1000 }}">
+          </div>
+          <div class="mb-3">
+            <label class="form-label" for="seed">Random seed (optional)</label>
+            <input class="form-control" id="seed" name="seed" type="number" value="{{ last_run.seed if last_run and last_run.seed is not none else '' }}">
+          </div>
+          <div class="form-check form-switch mb-2">
+            <input class="form-check-input" id="generate_data" name="generate_data" type="checkbox" {% if last_run and last_run.generate_data %}checked{% endif %}>
+            <label class="form-check-label" for="generate_data">Generate mock data before running</label>
+          </div>
+          <div class="form-check form-switch mb-2">
+            <input class="form-check-input" id="dry_run" name="dry_run" type="checkbox" {% if last_run and last_run.dry_run %}checked{% endif %}>
+            <label class="form-check-label" for="dry_run">Dry-run (skip report generation &amp; persistence)</label>
+          </div>
+          <div class="form-check form-switch mb-2">
+            <input class="form-check-input" id="auto_approve" name="auto_approve" type="checkbox" {% if last_run and last_run.auto_approve %}checked{% endif %}>
+            <label class="form-check-label" for="auto_approve">Auto-approve proposed master keys</label>
+          </div>
+          <div class="form-check form-switch mb-4">
+            <input class="form-check-input" id="verbose" name="verbose" type="checkbox" {% if last_run and last_run.verbose %}checked{% endif %}>
+            <label class="form-check-label" for="verbose">Capture verbose logs</label>
+          </div>
+          <div class="d-grid">
+            <button class="btn btn-primary" type="submit">Run reconciliation</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div class="col-lg-8">
+    {% if last_run %}
+      {% if last_run.status == 'success' %}
+        <div class="card shadow-sm mb-4">
+          <div class="card-header">Latest run &mdash; ID {{ last_run.run_id }}</div>
+          <div class="card-body">
+            <div class="row g-3">
+              <div class="col-md-6">
+                <dl class="row mb-0">
+                  <dt class="col-sm-6">Mode</dt>
+                  <dd class="col-sm-6">{{ last_run.mode|capitalize }}</dd>
+                  <dt class="col-sm-6">Execution</dt>
+                  <dd class="col-sm-6">{{ last_run.execution_mode.replace('-', ' ') if last_run.execution_mode else 'n/a' }}</dd>
+                  <dt class="col-sm-6">Scenario</dt>
+                  <dd class="col-sm-6">{{ last_run.scenario|capitalize }}</dd>
+                  <dt class="col-sm-6">Generated data</dt>
+                  <dd class="col-sm-6">{{ 'Yes' if last_run.generate_data else 'No' }}</dd>
+                </dl>
+              </div>
+              <div class="col-md-6">
+                <dl class="row mb-0">
+                  <dt class="col-sm-6">Dry run</dt>
+                  <dd class="col-sm-6">{{ 'Yes' if last_run.dry_run else 'No' }}</dd>
+                  <dt class="col-sm-6">Auto-approve</dt>
+                  <dd class="col-sm-6">{{ 'Yes' if last_run.auto_approve else 'No' }}</dd>
+                  <dt class="col-sm-6">Output directory</dt>
+                  <dd class="col-sm-6"><code>{{ last_run.output_dir }}</code></dd>
+                  <dt class="col-sm-6">Timestamp</dt>
+                  <dd class="col-sm-6">{{ last_run.view.timestamp or 'n/a' }}</dd>
+                </dl>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="card shadow-sm mb-4">
+          <div class="card-header">Key statistics</div>
+          <div class="card-body">
+            <div class="row g-3">
+              <div class="col-md-6">
+                <table class="table table-sm align-middle">
+                  <tbody>
+                    {% for label, value in last_run.view.stats_items %}
+                      <tr>
+                        <td>{{ label }}</td>
+                        <td class="text-end">{{ value }}</td>
+                      </tr>
+                    {% endfor %}
+                  </tbody>
+                </table>
+              </div>
+              <div class="col-md-6">
+                <table class="table table-sm align-middle">
+                  <thead>
+                    <tr>
+                      <th>System</th>
+                      <th class="text-end">Keys</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {% for system, count in last_run.view.system_counts %}
+                      <tr>
+                        <td>{{ system }}</td>
+                        <td class="text-end">{{ count }}</td>
+                      </tr>
+                    {% endfor %}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="card shadow-sm mb-4">
+          <div class="card-header">Discrepancy overview</div>
+          <div class="card-body">
+            <div class="row g-3">
+              <div class="col-md-6">
+                <table class="table table-sm align-middle">
+                  <tbody>
+                    {% for label, value in last_run.view.discrepancy_summary %}
+                      <tr>
+                        <td>{{ label }}</td>
+                        <td class="text-end">{{ value }}</td>
+                      </tr>
+                    {% endfor %}
+                  </tbody>
+                </table>
+                {% if last_run.view.duplicate_counts %}
+                  <p class="mb-0"><strong>Duplicate groups</strong></p>
+                  <ul class="small">
+                    {% for system, count in last_run.view.duplicate_counts.items() %}
+                      <li>{{ system }}: {{ count }}</li>
+                    {% endfor %}
+                  </ul>
+                {% endif %}
+              </div>
+              <div class="col-md-6">
+                {% if last_run.view.propagation_gaps %}
+                  <details open>
+                    <summary>Propagation gaps by system</summary>
+                    <ul class="small mt-2">
+                      {% for system, keys in last_run.view.propagation_gaps.items() %}
+                        <li><strong>{{ system }}</strong>: {{ keys|length }} gaps</li>
+                      {% endfor %}
+                    </ul>
+                  </details>
+                {% else %}
+                  <p class="text-muted">No propagation gaps detected.</p>
+                {% endif %}
+                {% if last_run.view.keys_missing_in_a %}
+                  <details class="mt-3">
+                    <summary>Keys missing in System A</summary>
+                    <p class="small mt-2 mb-0">Showing up to 25 keys.</p>
+                    <ul class="small mt-1">
+                      {% for key in last_run.view.keys_missing_in_a[:25] %}
+                        <li><code>{{ key }}</code></li>
+                      {% endfor %}
+                    </ul>
+                  </details>
+                {% endif %}
+              </div>
+            </div>
+            {% if last_run.view.out_of_authority %}
+              <details class="mt-3">
+                <summary>Out-of-authority keys</summary>
+                <div class="table-responsive mt-2">
+                  <table class="table table-sm">
+                    <thead>
+                      <tr>
+                        <th>Normalized key</th>
+                        <th>Source systems</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {% set max_rows = 25 %}
+                      {% for entry in last_run.view.out_of_authority[:max_rows] %}
+                        <tr>
+                          <td><code>{{ entry.normalized_key }}</code></td>
+                          <td>
+                            {% for system, original in entry.sources %}
+                              <span class="badge bg-secondary me-1">{{ system }}: {{ original }}</span>
+                            {% endfor %}
+                          </td>
+                        </tr>
+                      {% endfor %}
+                      {% if last_run.view.out_of_authority|length > max_rows %}
+                        <tr>
+                          <td colspan="2" class="text-muted small">Showing first {{ max_rows }} of {{ last_run.view.out_of_authority|length }} entries.</td>
+                        </tr>
+                      {% endif %}
+                    </tbody>
+                  </table>
+                </div>
+              </details>
+            {% else %}
+              <p class="text-muted mb-0">No out-of-authority keys identified.</p>
+            {% endif %}
+          </div>
+        </div>
+        {% if last_run.view.provisioning %}
+          <div class="card shadow-sm mb-4">
+            <div class="card-header">Proposed master keys</div>
+            <div class="card-body table-responsive">
+              <table class="table table-sm align-middle">
+                <thead>
+                  <tr>
+                    <th>Master key</th>
+                    <th>Source system</th>
+                    <th>Source key</th>
+                    <th>Affected systems</th>
+                    <th>Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for item in last_run.view.provisioning %}
+                    <tr>
+                      <td><code>{{ item.master_key }}</code></td>
+                      <td>{{ item.source_system }}</td>
+                      <td><code>{{ item.source_key }}</code></td>
+                      <td>
+                        {% if item.affected_systems %}
+                          {% for system in item.affected_systems %}
+                            <span class="badge bg-secondary me-1">{{ system }}</span>
+                          {% endfor %}
+                        {% else %}
+                          &mdash;
+                        {% endif %}
+                      </td>
+                      <td>{{ item.status|capitalize }}</td>
+                    </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        {% endif %}
+        <div class="card shadow-sm mb-4">
+          <div class="card-header">Generated outputs</div>
+          <div class="card-body">
+            {% if last_run.dry_run %}
+              <p class="text-muted mb-0">Dry run was enabled; reports were not generated.</p>
+            {% else %}
+              {% if last_run.report_files %}
+                <ul class="list-unstyled mb-2">
+                  {% for name in last_run.report_files %}
+                    <li><a href="{{ url_for('download_report', filename=name) }}">{{ name }}</a></li>
+                  {% endfor %}
+                  {% if last_run.json_report_name %}
+                    <li><a href="{{ url_for('download_report', filename=last_run.json_report_name) }}">{{ last_run.json_report_name }}</a></li>
+                  {% endif %}
+                </ul>
+              {% else %}
+                <p class="text-muted">No report files were produced.</p>
+              {% endif %}
+            {% endif %}
+          </div>
+        </div>
+        {% if last_run.generated_data %}
+          <div class="card shadow-sm mb-4">
+            <div class="card-header">Mock data generation summary</div>
+            <div class="card-body">
+              <p class="mb-2">Scenario: <strong>{{ last_run.generated_data.scenario|capitalize }}</strong> &middot; Seed: <code>{{ last_run.generated_data.seed }}</code></p>
+              <div class="table-responsive">
+                <table class="table table-sm align-middle">
+                  <thead>
+                    <tr>
+                      <th>System</th>
+                      <th class="text-end">Total records</th>
+                      <th class="text-end">Unique keys</th>
+                      <th class="text-end">Duplicates</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {% for system, stats in last_run.generated_data.systems.items() %}
+                      <tr>
+                        <td>{{ system }}</td>
+                        <td class="text-end">{{ stats.total_records }}</td>
+                        <td class="text-end">{{ stats.unique_keys }}</td>
+                        <td class="text-end">{{ stats.duplicates }}</td>
+                      </tr>
+                    {% endfor %}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        {% endif %}
+        <div class="card shadow-sm">
+          <div class="card-header">Run logs{% if last_run.verbose %} (verbose){% endif %}</div>
+          <div class="card-body">
+            {% if last_run.logs %}
+              <pre class="logs">{{ last_run.logs }}</pre>
+            {% else %}
+              <p class="text-muted mb-0">No logs were captured for this run.</p>
+            {% endif %}
+          </div>
+        </div>
+      {% else %}
+        <div class="card shadow-sm">
+          <div class="card-header">Last run failed</div>
+          <div class="card-body">
+            <p class="text-danger">{{ last_run.error }}</p>
+            {% if last_run.logs %}
+              <pre class="logs">{{ last_run.logs }}</pre>
+            {% endif %}
+          </div>
+        </div>
+      {% endif %}
+    {% else %}
+      <div class="card shadow-sm">
+        <div class="card-header">No runs yet</div>
+        <div class="card-body">
+          <p class="mb-0">Submit the form to generate mock data (optional) and launch a reconciliation run. The dashboard will display key statistics, discrepancies, and report links once complete.</p>
+        </div>
+      </div>
+    {% endif %}
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- factor the CLI workflow into a reusable `run_reconciliation` helper that returns structured results
- build a Flask-based dashboard with templates to launch runs, inspect statistics, discrepancies, generated data, and download reports
- document the new frontend, add Flask as a dependency, and cover the shared runner/view-model logic with tests

## Testing
- pytest tests


------
https://chatgpt.com/codex/tasks/task_e_68cab5cf149883329ca976d9d4f5741d